### PR TITLE
#TR-58 - Create Sub Class and Add on Class Schema

### DIFF
--- a/src/interfaces/DungeonsAndDragons5e.ts
+++ b/src/interfaces/DungeonsAndDragons5e.ts
@@ -136,6 +136,11 @@ export interface ClassCharacteristics {
   description: string;
 }
 
+export interface SubClass {
+  title: string;
+  description: string;
+  characteristics: ClassCharacteristics[];
+}
 export interface Class {
   name: string;
   description: string;
@@ -144,6 +149,7 @@ export interface Class {
   equipment: Equipment[];
   levelingSpecs: LevelingSpecs;
   characteristics: ClassCharacteristics[];
+  subClass: SubClass; 
 }
 
 // Feat entity

--- a/src/interfaces/User.ts
+++ b/src/interfaces/User.ts
@@ -1,5 +1,3 @@
-import { ImageObject } from "./Common";
-
 export interface InProgress {
     status: 'done' | 'wait_to_complete' |'wait_to_confirm' | 'wait_to_delete' | 'wait_to_verify';
     code: string;
@@ -35,6 +33,12 @@ export interface TwoFactorSecret {
     active: boolean;
 }
 
+export interface Picture {
+    id: string;
+    link: string;
+    uploadDate: Date;
+}
+
 export default interface User {
     userId?: string;
     inProgress?: InProgress;
@@ -43,7 +47,7 @@ export default interface User {
     password: string;
     nickname?: string;
     tag?: string;
-    picture?: ImageObject;
+    picture?: Picture;
     twoFactorSecret?: TwoFactorSecret;
     createdAt?: string;
     updatedAt?: string;

--- a/src/models/dungeons&dragons5e/ClassesModel.ts
+++ b/src/models/dungeons&dragons5e/ClassesModel.ts
@@ -1,6 +1,6 @@
 import mongoose, { Schema } from 'mongoose';
 import MongoModel from '../../models/MongoModel';
-import { HitPoints, Proficiencies, Equipment, CantripsKnown, SpellSlotsPerSpellLevel, SpellsKnown, KiPoints, MartialArts, UnarmoredMovement, SneakAttack, SorceryPoints, InvocationsKnown, Rages, RageDamage, LevelingSpecs, ClassCharacteristics, Class } from '../../interfaces/DungeonsAndDragons5e';
+import { HitPoints, Proficiencies, Equipment, CantripsKnown, SpellSlotsPerSpellLevel, SpellsKnown, KiPoints, MartialArts, UnarmoredMovement, SneakAttack, SorceryPoints, InvocationsKnown, Rages, RageDamage, LevelingSpecs, ClassCharacteristics, Class, SubClass } from '../../interfaces/DungeonsAndDragons5e';
 import { Internacional } from '../../interfaces/Internacional';
 import newUUID from '../../helpers/newUUID';
 
@@ -149,6 +149,15 @@ const characteristicsMongooseSchema = new Schema<ClassCharacteristics>(
     { versionKey: false, _id: false }
 );
 
+const subClassMoongoseSchema = new Schema<SubClass>(
+    {
+        title: { type: String, required: true },
+        description: { type: String },
+        characteristics: [characteristicsMongooseSchema]
+    },
+    { versionKey: false, _id: false }
+)
+
 const schema = new Schema<Class>(
     {
         name: { type: String, required: true },
@@ -158,6 +167,7 @@ const schema = new Schema<Class>(
         equipment: [equipmentMongooseSchema],
         levelingSpecs: levelingSpecsMongooseSchema,
         characteristics: [characteristicsMongooseSchema],
+        subClass: [subClassMoongoseSchema]
     },
     { versionKey: false, _id: false }
 );


### PR DESCRIPTION
Ao adicionar os conteúdos de classe foi notado que existe um sistema de sub-classes no D&D, este sistema não foi previsto nem implementado, essa task consiste  em adicionar o campo subClasses no schema de classes do D&D.

Esse campo seguirá a seguinte estrutura:

```
subClasses: [
  {
    title: “…”,
    description: “…“,
    characteristics: [
      {
        title: “…“,
        description: “…“
      } 
    ]
  }
]
```